### PR TITLE
Modified code to accept as per need

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,7 @@ dmypy.json
 .pyre/
 .downloads/
 .tempdir/
+tempdir/
 reports/
 test_report.html
 integration_test_report.html

--- a/README.md
+++ b/README.md
@@ -108,11 +108,32 @@ graph LR;
   A(gtfs-flex-upload)-->B[gtfs-flex-validation-service];
   B-->C(gtfs-flex-validation)
 ```
-#### Incoming
-The incoming messages will be from the upload queue `gtfs-flex-upload`.
-The format is mentioned in [msg-gtfs-flex-upload.json](./src/assets/msg-gtfs-flex-upload.json)
+#### Incoming Message
+```json
+{
+    "messageId": "c8c76e89f30944d2b2abd2491bd95337",
+    "messageType": "workflow_identifier",
+    "data": {
+      "file_upload_path": "https://tdeisamplestorage.blob.core.windows.net/gtfsflex/tests/success_1_all_attrs.zip",
+      "user_id": "c59d29b6-a063-4249-943f-d320d15ac9ab",
+      "tdei_project_group_id": "0b41ebc5-350c-42d3-90af-3af4ad3628fb"
+    }
+  }
+```
 
-#### Outgoing
-The outgoing messages will be to the `gtfs-flex-validation` topic.
-The format of the message is at [gtfs-flex-validation.json](./src/assets/msg-gtfs-flex-validation.json)
+#### Outgoing Message
+```json
+{
+    "messageId": "c8c76e89f30944d2b2abd2491bd95337",
+    "messageType": "workflow_identifier",
+    "data": {
+      "file_upload_path": "https://tdeisamplestorage.blob.core.windows.net/osw/test_upload/valid.zip",
+      "user_id": "c59d29b6-a063-4249-943f-d320d15ac9ab",
+      "tdei_project_group_id": "0b41ebc5-350c-42d3-90af-3af4ad3628fb",
+      "success": true,
+      "message": ""
+    }
+  }
+
+```
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ The project is built on Python with FastAPI framework. All the regular nuances f
 - Connecting this to cloud will need the following in the `.env` file
 
 ```bash
-UPLOAD_TOPIC=xxxx
-UPLOAD_SUBSCRIPTION=xxxx
-VALIDATION_TOPIC=xxxx
+REQUEST_TOPIC=xxxx
+RESPONSE_TOPIC=xxxx
+REQUEST_SUBSCRIPTION=xxxx
 QUEUECONNECTION=xxxx
 STORAGECONNECTION=xxxx
 ```

--- a/src/assets/request-msg.json
+++ b/src/assets/request-msg.json
@@ -1,0 +1,9 @@
+{
+    "messageId": "c8c76e89f30944d2b2abd2491bd95337",
+    "messageType": "workflow_identifier",
+    "data": {
+      "file_upload_path": "https://tdeisamplestorage.blob.core.windows.net/gtfsflex/tests/success_1_all_attrs.zip",
+      "user_id": "c59d29b6-a063-4249-943f-d320d15ac9ab",
+      "tdei_project_group_id": "0b41ebc5-350c-42d3-90af-3af4ad3628fb"
+    }
+  }

--- a/src/assets/response-msg.json
+++ b/src/assets/response-msg.json
@@ -1,0 +1,11 @@
+{
+    "messageId": "c8c76e89f30944d2b2abd2491bd95337",
+    "messageType": "workflow_identifier",
+    "data": {
+      "file_upload_path": "https://tdeisamplestorage.blob.core.windows.net/osw/test_upload/valid.zip",
+      "user_id": "c59d29b6-a063-4249-943f-d320d15ac9ab",
+      "tdei_project_group_id": "0b41ebc5-350c-42d3-90af-3af4ad3628fb",
+      "success": true,
+      "message": ""
+    }
+  }

--- a/src/config.py
+++ b/src/config.py
@@ -7,8 +7,7 @@ load_dotenv()
 
 class Settings(BaseSettings):
     app_name: str = 'gtfs-flex-validation-service-python'
-    subscription_topic_name: str = os.environ.get('UPLOAD_TOPIC', None)
-    publishing_topic_name: str = os.environ.get('VALIDATION_TOPIC', None)
-    subscription_name: str = os.environ.get('UPLOAD_SUBSCRIPTION', None)
-    validation_topic: str = os.environ.get('VALIDATION_TOPIC', None)
+    request_topic_name: str = os.environ.get('REQUEST_TOPIC', None)
+    response_topic_name: str = os.environ.get('RESPONSE_TOPIC', None)
+    request_subscription: str = os.environ.get('REQUEST_SUBSCRIPTION', None)
     storage_container_name: str = os.environ.get('CONTAINER_NAME', 'gtfsflex')

--- a/src/gtfx_flex_validator.py
+++ b/src/gtfx_flex_validator.py
@@ -6,6 +6,7 @@ from python_ms_core.core.queue.models.queue_message import QueueMessage
 from .config import Settings
 from .gtfs_flex_validation import GTFSFlexValidation
 from .serializer.gtfx_flex_serializer import GTFSFlexUpload
+from .models.file_upload_msg import FileUploadMsg
 
 logging.basicConfig()
 logger = logging.getLogger('FLEX_VALIDATOR')
@@ -30,14 +31,17 @@ class GTFSFlexValidator:
         def process(message) -> None:
             if message is not None:
                 gtfs_upload_message = QueueMessage.to_dict(message)
-                upload_message = GTFSFlexUpload.data_from(gtfs_upload_message)
-                file_upload_path = urllib.parse.unquote(upload_message.data.meta.file_upload_path)
-                logger.info(f' Received message for Record: {upload_message.data.tdei_record_id}')
+                upload_msg = FileUploadMsg.from_dict(gtfs_upload_message)
+                logger.info(upload_msg)
+                # upload_message = GTFSFlexUpload.data_from(gtfs_upload_message)
+                file_upload_path = urllib.parse.unquote(upload_msg.data.file_upload_path)
+                logger.info(f' Received message for Project Group: {upload_msg.data.tdei_project_group_id}')
+                logger.info(file_upload_path)
                 if file_upload_path:
                     # Do the validation in the other class
                     validator = GTFSFlexValidation(file_path=file_upload_path, storage_client=self.storage_client)
                     validation = validator.validate()
-                    self.send_status(valid=validation[0], upload_message=upload_message,
+                    self.send_status(valid=validation[0], upload_message=upload_msg,
                                      validation_message=validation[1])
                 else:
                     logger.info(' No file Path found in message!')
@@ -46,19 +50,26 @@ class GTFSFlexValidator:
 
         self.listening_topic.subscribe(subscription=self._subscription_name, callback=process)
 
-    def send_status(self, valid: bool, upload_message: GTFSFlexUpload, validation_message: str = '') -> None:
-        upload_message.data.stage = 'flex-validation'
-        upload_message.data.meta.isValid = valid
-        upload_message.data.meta.validationMessage = validation_message or 'Validation successful'
-        upload_message.data.response.success = valid
-        upload_message.data.response.message = validation_message or 'Validation successful'
-        message_id = uuid.uuid1().hex[0:24]
-        logger.info(f' Publishing new message with ID: {message_id} with status: {upload_message.data.response.success} and Message: {upload_message.data.response.message}')
+    def send_status(self, valid: bool, upload_message: FileUploadMsg, validation_message: str = '') -> None:
+        # upload_message.data.stage = 'flex-validation'
+        # upload_message.data.meta.isValid = valid
+        # upload_message.data.meta.validationMessage = validation_message or 'Validation successful'
+        # upload_message.data.response.success = valid
+        # upload_message.data.response.message = validation_message or 'Validation successful'
+        # message_id = uuid.uuid1().hex[0:24]
+        response_message = {
+             "file_upload_path": upload_message.data.file_upload_path,
+      "user_id": upload_message.data.user_id ,
+      "tdei_project_group_id": upload_message.data.tdei_project_group_id,
+      "success": valid,
+      "message": validation_message
+        }
+        logger.info(f' Publishing new message with ID: {upload_message.messageId} with status: {valid} and Message: {validation_message}')
         data = QueueMessage.data_from({
-            'messageId': message_id,
-            'message': upload_message.message or 'Validation complete',
-            'messageType': 'gtfs-flex-validation',
-            'data': upload_message.data.to_json()
+            'messageId': upload_message.messageId,
+            'message':  'Validation complete',
+            'messageType': upload_message.messageType,
+            'data': response_message
         })
         self.publish_topic.publish(data=data)
         return

--- a/src/gtfx_flex_validator.py
+++ b/src/gtfx_flex_validator.py
@@ -19,9 +19,9 @@ class GTFSFlexValidator:
     def __init__(self):
         core = Core()
         settings = Settings()
-        self._subscription_name = settings.subscription_name
-        self.listening_topic = core.get_topic(topic_name=settings.subscription_topic_name)
-        self.publish_topic = core.get_topic(topic_name=settings.publishing_topic_name)
+        self._subscription_name = settings.request_subscription
+        self.request_topic = core.get_topic(topic_name=settings.request_topic_name)
+        self.response_topic = core.get_topic(topic_name=settings.response_topic_name)
         self.logger = core.get_logger()
         self.storage_client = core.get_storage_client()
         self.subscribe()
@@ -48,7 +48,7 @@ class GTFSFlexValidator:
             else:
                 logger.info(' No Message')
 
-        self.listening_topic.subscribe(subscription=self._subscription_name, callback=process)
+        self.request_topic.subscribe(subscription=self._subscription_name, callback=process)
 
     def send_status(self, valid: bool, upload_message: FileUploadMsg, validation_message: str = '') -> None:
         # upload_message.data.stage = 'flex-validation'
@@ -71,5 +71,5 @@ class GTFSFlexValidator:
             'messageType': upload_message.messageType,
             'data': response_message
         })
-        self.publish_topic.publish(data=data)
+        self.response_topic.publish(data=data)
         return

--- a/src/models/file_upload_msg.py
+++ b/src/models/file_upload_msg.py
@@ -6,7 +6,7 @@ from typing import Optional, Dict
 class IncomingData:
     file_upload_path:str
     user_id:str 
-    tdei_project_group_id: str
+    tdei_project_group_id: Optional[str] = ""
 
 @dataclass
 class FileUploadMsg: 

--- a/src/models/file_upload_msg.py
+++ b/src/models/file_upload_msg.py
@@ -1,0 +1,28 @@
+# class to hold the file upload message
+from dataclasses import dataclass
+from typing import Optional, Dict
+
+@dataclass
+class IncomingData:
+    file_upload_path:str
+    user_id:str 
+    tdei_project_group_id: str
+
+@dataclass
+class FileUploadMsg: 
+    messageId:str 
+    messageType: str
+    data: IncomingData
+    
+    @classmethod
+    def from_dict(cls, data:Dict):
+        incoming_data = data.get('data')
+        if incoming_data:
+            theData = IncomingData(**incoming_data)
+        else:
+            theData = None
+        return cls(
+            messageId = data.get('messageId'),
+            messageType = data.get('messageType'),
+            data = theData
+        )

--- a/test_report.py
+++ b/test_report.py
@@ -6,6 +6,7 @@ from tests.unit_tests.test_gtfs_flex_serializer import TestGTFSFlexUpload, TestG
     TestMeta, TestResponse
 from tests.unit_tests.test_gtfs_flex_validation import TestSuccessGTFSFlexValidation, TestFailureGTFSFlexValidation
 from tests.unit_tests.test_gtfx_flex_validator import TestGTFSFlexValidator
+from tests.unit_tests.test_file_upload_msg import TestFileUploadMsg
 from tests.unit_tests.test_main import TestApp
 
 if __name__ == '__main__':
@@ -21,6 +22,7 @@ if __name__ == '__main__':
     test_suite.addTest(unittest.makeSuite(TestFailureGTFSFlexValidation))
     test_suite.addTest(unittest.makeSuite(TestGTFSFlexValidator))
     test_suite.addTest(unittest.makeSuite(TestApp))
+    test_suite.addTest(unittest.makeSuite(TestFileUploadMsg))
 
     # Define the output file for the HTML report
     output_file = 'test_report.html'

--- a/tests/integration_tests/test_gtfs_flex_integration.py
+++ b/tests/integration_tests/test_gtfs_flex_integration.py
@@ -61,7 +61,7 @@ class TestGTFSFlexIntegration(unittest.TestCase):
         validator = GTFSFlexValidator()
         subscribe_function = MagicMock()
         message = QueueMessage.data_from({'message': '', 'data': self.test_data})
-        validator.publish_topic.publish(data=message)
+        validator.response_topic.publish(data=message)
         validation_topic = self.core.get_topic(topic_name=self.validation_topic_name)
         async with validation_topic.subscribe(subscription='temp-validation-result', callback=subscribe_function):
             await asyncio.sleep(0.5)  # Wait for callback

--- a/tests/unit_tests/test_file_upload_msg.py
+++ b/tests/unit_tests/test_file_upload_msg.py
@@ -1,0 +1,29 @@
+import os
+import json
+import unittest
+from src.models.file_upload_msg import FileUploadMsg
+# from src.gtfx_flex_validator import GTFSFlexValidator
+
+current_dir = os.path.dirname(os.path.abspath(os.path.join(__file__, '../')))
+parent_dir = os.path.dirname(current_dir)
+
+TEST_JSON_FILE = os.path.join(parent_dir, 'src/assets/request-msg.json')
+TEST_FILE = open(TEST_JSON_FILE)
+TEST_DATA = json.loads(TEST_FILE.read())
+
+class TestFileUploadMsg(unittest.TestCase):
+    def setUp(self):
+        data = TEST_DATA
+        self.upload = FileUploadMsg.from_dict(data=data)
+    
+    def test_message_type(self):
+        self.assertEqual(self.upload.messageType,"workflow_identifier")
+    def test_message_id(self):
+        self.upload.messageId = "abc"
+        self.assertEqual(self.upload.messageId,"abc")
+    def test_file_upload_path(self):
+        self.assertEqual(self.upload.data.file_upload_path,'https://tdeisamplestorage.blob.core.windows.net/gtfsflex/tests/success_1_all_attrs.zip')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit_tests/test_gtfx_flex_validator.py
+++ b/tests/unit_tests/test_gtfx_flex_validator.py
@@ -9,8 +9,8 @@ class TestGTFSFlexValidator(unittest.TestCase):
         with patch.object(GTFSFlexValidator, '__init__', return_value=None):
             self.validator = GTFSFlexValidator()
             self.validator._subscription_name = MagicMock()
-            self.validator.listening_topic = MagicMock()
-            self.validator.publish_topic = MagicMock()
+            self.validator.request_topic = MagicMock()
+            self.validator.response_topic = MagicMock()
             self.validator.logger = MagicMock()
             self.validator.storage_client = MagicMock()
 


### PR DESCRIPTION
Modified the request response messages format

The incoming format will be changed to 

```json
{
    "messageId": "c8c76e89f30944d2b2abd2491bd95337",
    "messageType": "workflow_identifier",
    "data": {
      "file_upload_path": "https://tdeisamplestorage.blob.core.windows.net/gtfsflex/tests/success_1_all_attrs.zip",
      "user_id": "c59d29b6-a063-4249-943f-d320d15ac9ab",
      "tdei_project_group_id": "0b41ebc5-350c-42d3-90af-3af4ad3628fb"
    }
  }
```

The outgoing message will be of format:
```json
{
    "messageId": "c8c76e89f30944d2b2abd2491bd95337",
    "messageType": "workflow_identifier",
    "data": {
      "file_upload_path": "https://tdeisamplestorage.blob.core.windows.net/osw/test_upload/valid.zip",
      "user_id": "c59d29b6-a063-4249-943f-d320d15ac9ab",
      "tdei_project_group_id": "0b41ebc5-350c-42d3-90af-3af4ad3628fb",
      "success": true,
      "message": ""
    }
  }

```

NOTE: This breaks the service for old message structure. Need to figure out how to handle that as well.