### PR TITLE
Multi thread issue fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,12 @@ RESPONSE_TOPIC=xxxx
 REQUEST_SUBSCRIPTION=xxxx
 QUEUECONNECTION=xxxx
 STORAGECONNECTION=xxxx
+MAX_CONCURRENT_MESSAGES=xx
 ```
 The application connect with the `STORAGECONNECTION` string provided in `.env` file and validates downloaded zipfile using `tdei-gtfs-csv-validator` package.
 `QUEUECONNECTION` is not being used in this application but this is the main requirement for `python-ms-core` package
+
+`MAX_CONCURRENT_MESSAGES` is the maximum number of concurrent messages that the service can handle. If not provided, defaults to 1
 
 ### How to Setup and Build
 Follow the steps to install the node packages required for both building and running the application.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ fastapi~=0.111.1
 pydantic==1.10.4
 html_testRunner==1.2.1
 uvicorn==0.20.0
-python-ms-core==0.0.19
+python-ms-core==0.0.21
 tcat-gtfs-csv-validator~=0.0.38

--- a/src/config.py
+++ b/src/config.py
@@ -12,6 +12,7 @@ class Settings(BaseSettings):
     response_topic_name: str = os.environ.get('RESPONSE_TOPIC', None)
     request_subscription: str = os.environ.get('REQUEST_SUBSCRIPTION', None)
     storage_container_name: str = os.environ.get('CONTAINER_NAME', 'gtfsflex')
+    max_concurrent_messages: int = os.environ.get('MAX_CONCURRENT_MESSAGES', 1)
 
     def get_unique_id(self) -> str:
         return str(uuid.uuid4())

--- a/src/gtfx_flex_validator.py
+++ b/src/gtfx_flex_validator.py
@@ -42,17 +42,22 @@ class GTFSFlexValidator:
         self.request_topic.subscribe(subscription=self._subscription_name, callback=process)
     
     def process_message(self, upload_msg: FileUploadMsg) -> None:
-        file_upload_path = urllib.parse.unquote(upload_msg.data.file_upload_path)
-        logger.info(f' Received message for Project Group: {upload_msg.data.tdei_project_group_id}')
-        logger.info(file_upload_path)
-        if file_upload_path:
-            # Do the validation in the other class
-            validator = GTFSFlexValidation(file_path=file_upload_path, storage_client=self.storage_client)
-            validation = validator.validate()
-            self.send_status(valid=validation[0], upload_message=upload_msg,
-                                    validation_message=validation[1])
-        else:
-            logger.info(' No file Path found in message!')
+
+        try:
+            file_upload_path = urllib.parse.unquote(upload_msg.data.file_upload_path)
+            logger.info(f' Received message for Project Group: {upload_msg.data.tdei_project_group_id}')
+            logger.info(file_upload_path)
+            if file_upload_path:
+                # Do the validation in the other class
+                validator = GTFSFlexValidation(file_path=file_upload_path, storage_client=self.storage_client)
+                validation = validator.validate()
+                self.send_status(valid=validation[0], upload_message=upload_msg,
+                                        validation_message=validation[1])
+            else:
+                logger.info(' No file Path found in message!')
+        except Exception as e:
+            logger.error(f' Error processing message: {e}')
+            self.send_status(valid=False, upload_message=upload_msg, validation_message=str(e))
 
     def send_status(self, valid: bool, upload_message: FileUploadMsg, validation_message: str = '') -> None:
         response_message = {


### PR DESCRIPTION
- Fixes the issue with multi threaded approach
- There is an inherent issue in the Library where the files are extracted to the same folder everytime. 
- This is fixed by using 1 concurrent message at a time and processing it
- Also removed creation of a separate thread each time. The messages are received in a threadpool execution manner and need not be handled by a separate thread each time.
### Testing
- This is tested with a sample topic and a sample message is run 10 times and 15 times in two consecutive sessions. Both times, it was able to execute and respond with all the required parameters and details.