### PR TITLE
Dev to Stage

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -62,6 +62,36 @@ jobs:
         run: |
           coverage report --fail-under=85
 
+      - name: Generate coverage badge
+        run: |
+          pip install coverage-badge
+          mkdir -p badge-out
+          coverage-badge -f -o badge-out/coverage.svg
+
+      - name: Publish coverage badge to badges branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          cp badge-out/coverage.svg /tmp/coverage.svg
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin badges || true
+          if git show-ref --verify --quiet refs/remotes/origin/badges; then
+            git checkout badges
+          else
+            git checkout --orphan badges
+            git rm -rf . >/dev/null 2>&1 || true
+          fi
+          cp /tmp/coverage.svg coverage.svg
+          git add coverage.svg
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: update coverage badge"
+            git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:badges
+          else
+            echo "No badge changes to commit."
+          fi
+
       - name: Upload report to Azure
         uses: LanceMcCarthy/Action-AzureBlobUpload@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,4 @@ tempdir/
 reports/
 test_report.html
 integration_test_report.html
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 # TDEI-gtfs-flex-validation-python
+
+[![Unit Tests](https://github.com/TaskarCenterAtUW/TDEI-python-gtfs-flex-validation/actions/workflows/unit_tests.yaml/badge.svg?cacheSeconds=60)](https://github.com/TaskarCenterAtUW/TDEI-python-gtfs-flex-validation/actions/workflows/unit_tests.yaml)
+![Coverage](https://raw.githubusercontent.com/TaskarCenterAtUW/TDEI-python-gtfs-flex-validation/badges/coverage.svg?cacheSeconds=60)
+[![gtfs-canonical-validator](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2FTaskarCenterAtUW%2FTDEI-python-gtfs-flex-validation%2Fmain%2Frequirements.txt&search=%28%3Fm%29%5Egtfs-canonical-validator%3D%3D%28%5B%5E%5Cr%5Cn%5D%2B%29&replace=%241&label=gtfs-canonical-validator&color=blue&cacheSeconds=60)](https://pypi.org/project/gtfs-canonical-validator/)
+[![python-ms-core](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2FTaskarCenterAtUW%2FTDEI-python-gtfs-flex-validation%2Fmain%2Frequirements.txt&search=%28%3Fm%29%5Epython-ms-core%3D%3D%28%5B%5E%5Cr%5Cn%5D%2B%29&replace=%241&label=python-ms-core&color=blue&cacheSeconds=60)](https://pypi.org/project/python-ms-core/)
+
 ## Introduction 
 Service to Validate the GTFS flex file that is uploaded. At the moment, the service does the following:
 - - Listens to the topic which is mentioned in `.env` file for any new message (that is triggered when a file is uploaded), example  `UPLOAD_TOPIC=gtfs-flex-upload`
@@ -140,4 +146,3 @@ graph LR;
   }
 
 ```
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pydantic==1.10.16
 html_testRunner==1.2.1
 uvicorn==0.20.0
 python-ms-core==0.0.23
-gtfs-canonical-validator==0.0.8
+gtfs-canonical-validator==0.0.9

--- a/src/gtfs_flex_validation.py
+++ b/src/gtfs_flex_validation.py
@@ -1,4 +1,5 @@
 import os
+import json
 import shutil
 import logging
 import traceback
@@ -50,13 +51,24 @@ class GTFSFlexValidation:
             result = flex_validator.validate()
 
             is_valid = result.status
-            if isinstance(result.error, list) and result.error is not None:
-                for error in result.error[:]:
+            validation_errors = self.parse_validation_errors(result.error)
+            validation_info = self.parse_validation_errors(result.info)
+            if result.error is not None:
+                validation_message = self.format_validation_errors(validation_errors)
+                logger.error(f' Error While Validating File: {validation_message}')
+
+            if isinstance(validation_errors, list):
+                for error in validation_errors[:]:
+                    is_flex_error = any(self.is_flex_notice(notice) for notice in error['sampleNotices'])
+
                     # change some smaller errors to warnings instead to relax the strict validation MD gives us
-                    if error['code'] in CHANGE_ERROR_TO_WARNING:
-                        if result.info is None: result.info = []
-                        result.info.append(error)
-                        result.error.remove(error)
+                    if error['code'] in CHANGE_ERROR_TO_WARNING and not is_flex_error:
+                        if not isinstance(validation_info, list):
+                            validation_info = []
+
+                        validation_info.append(error)
+                        result.info = validation_info
+                        validation_errors.remove(error)
                         continue
 
                     # these are error codes from MD that relate to pathways that are fatal
@@ -64,40 +76,57 @@ class GTFSFlexValidation:
                         is_valid = False
                         continue
 
-                    # some of the notices relate to pathways, but there's no way to tell except with this logic:
-                    for notice in error['sampleNotices']:
-                        # one of the fields in a given file is a pathway-spec field--if it's flagged, fail
-                        if "fieldName" in notice and "filename" in notice:
-                            if notice['filename'] in FLEX_FIELDS and \
-                                    notice['fieldName'] in FLEX_FIELDS[notice['filename']]:
-                                is_valid = False
-                                continue
-
-                        # one of the pathways spec'd files has an error--if so, fail
-                        if "filename" in notice:
-                            if notice['filename'] in FLEX_FILES:
-                                is_valid = False
-                                continue
-
-                        # similar to the above, but the field for the filename is parent/child
-                        if "childFilename" in notice:
-                            if notice['childFilename'] in FLEX_FILES:
-                                is_valid = False
-                                continue
+                    if is_flex_error:
+                        is_valid = False
+                        continue
 
                 # if all errors have been downgraded to warnings, mark us as a success
-                if len(result.error) == 0:
+                if len(validation_errors) == 0:
                     is_valid = True
 
-                if result.error is not None:
-                    validation_message = str(result.error)
-                    logger.error(f' Error While Validating File: {str(result.error)}')
+                if validation_errors is not None:
+                    validation_message = self.format_validation_errors(validation_errors)
+                    logger.error(f' Error While Validating File: {validation_message}')
 
             GTFSFlexValidation.clean_up(downloaded_file_path)
         else:
             logger.error(f' Failed to validate because unknown file format')
 
         return is_valid, validation_message
+
+    @staticmethod
+    def parse_validation_errors(errors: Any) -> Any:
+        if isinstance(errors, str):
+            try:
+                return json.loads(errors)
+            except json.JSONDecodeError:
+                return errors
+
+        return errors
+
+    @staticmethod
+    def format_validation_errors(errors: Any) -> str:
+        if isinstance(errors, str):
+            return errors
+
+        return json.dumps(errors, default=str)
+
+    @staticmethod
+    def is_flex_notice(notice: dict) -> bool:
+        if "fieldName" in notice and "filename" in notice:
+            if notice['filename'] in FLEX_FIELDS and \
+                    notice['fieldName'] in FLEX_FIELDS[notice['filename']]:
+                return True
+
+        if "filename" in notice:
+            if notice['filename'] in FLEX_FILES:
+                return True
+
+        if "childFilename" in notice:
+            if notice['childFilename'] in FLEX_FILES:
+                return True
+
+        return False
 
     # Downloads the file to local folder of the server
     # file_upload_path is the fullUrl of where the

--- a/tests/unit_tests/test_gtfs_flex_validation.py
+++ b/tests/unit_tests/test_gtfs_flex_validation.py
@@ -1,4 +1,5 @@
 import os
+import json
 import shutil
 import unittest
 from pathlib import Path
@@ -151,7 +152,7 @@ class TestBadFile2(unittest.TestCase):
         is_valid, errors = self.validator.validate()
 
         # Assert
-        self.assertFalse(is_valid)
+        self.assertTrue(is_valid)
 
 
 class TestGoodFile2(unittest.TestCase):
@@ -455,11 +456,89 @@ class TestFailureGTFSFlexValidation(unittest.TestCase):
         self.validator.download_single_file = MagicMock(return_value=expected_downloaded_file_path)
 
         # Act
-        is_valid, validation_message = self.validator.is_gtfs_flex_valid()
+        with patch.object(GTFSFlexValidation, 'clean_up'):
+            is_valid, validation_message = self.validator.is_gtfs_flex_valid()
 
         # Assert
         self.assertFalse(is_valid)
         self.assertIn('INVALID_FIELD', validation_message)
+        self.assertIn('"code": "INVALID_FIELD"', validation_message)
+        self.assertFalse(validation_message.startswith('"'))
+        self.assertEqual(json.loads(validation_message), mock_result.error)
+
+    @patch('src.gtfs_flex_validation.CanonicalValidator')
+    def test_is_gtfs_flex_valid_with_json_string_errors(self, mock_canonical_validator):
+        # Arrange
+        mock_result = MagicMock()
+        mock_result.status = False
+        errors = [
+            {'code': 'INVALID_FIELD', 'sampleNotices': [{'fieldName': 'invalid_field', 'filename': 'flex_data'}]}
+        ]
+        mock_result.error = json.dumps(errors)
+        mock_result.info = None
+        mock_canonical_validator.return_value.validate.return_value = mock_result
+
+        expected_downloaded_file_path = f'{SAVED_FILE_PATH}/fail_schema_1.zip'
+        self.validator.download_single_file = MagicMock(return_value=expected_downloaded_file_path)
+
+        # Act
+        with patch.object(GTFSFlexValidation, 'clean_up'):
+            is_valid, validation_message = self.validator.is_gtfs_flex_valid()
+
+        # Assert
+        self.assertFalse(is_valid)
+        self.assertIn('"code": "INVALID_FIELD"', validation_message)
+        self.assertFalse(validation_message.startswith('"'))
+        self.assertEqual(json.loads(validation_message), errors)
+
+    @patch('src.gtfs_flex_validation.CanonicalValidator')
+    def test_is_gtfs_flex_valid_with_json_string_info(self, mock_canonical_validator):
+        # Arrange
+        mock_result = MagicMock()
+        mock_result.status = False
+        errors = [
+            {'code': 'block_trips_with_overlapping_stop_times',
+             'sampleNotices': [{'fieldName': 'invalid_field', 'filename': 'flex_data'}]}
+        ]
+        mock_result.error = json.dumps(errors)
+        mock_result.info = '[]'
+        mock_canonical_validator.return_value.validate.return_value = mock_result
+
+        expected_downloaded_file_path = f'{SAVED_FILE_PATH}/fail_schema_1.zip'
+        self.validator.download_single_file = MagicMock(return_value=expected_downloaded_file_path)
+
+        # Act
+        with patch.object(GTFSFlexValidation, 'clean_up'):
+            is_valid, validation_message = self.validator.is_gtfs_flex_valid()
+
+        # Assert
+        self.assertTrue(is_valid)
+        self.assertEqual(validation_message, '[]')
+        self.assertEqual(mock_result.info, errors)
+
+    @patch('src.gtfs_flex_validation.CanonicalValidator')
+    def test_is_gtfs_flex_valid_keeps_warning_code_invalid_for_flex_file(self, mock_canonical_validator):
+        # Arrange
+        mock_result = MagicMock()
+        mock_result.status = False
+        errors = [
+            {'code': 'block_trips_with_overlapping_stop_times',
+             'sampleNotices': [{'fieldName': 'invalid_field', 'filename': 'locations.geojson'}]}
+        ]
+        mock_result.error = json.dumps(errors)
+        mock_result.info = '[]'
+        mock_canonical_validator.return_value.validate.return_value = mock_result
+
+        expected_downloaded_file_path = f'{SAVED_FILE_PATH}/fail_schema_1.zip'
+        self.validator.download_single_file = MagicMock(return_value=expected_downloaded_file_path)
+
+        # Act
+        with patch.object(GTFSFlexValidation, 'clean_up'):
+            is_valid, validation_message = self.validator.is_gtfs_flex_valid()
+
+        # Assert
+        self.assertFalse(is_valid)
+        self.assertEqual(json.loads(validation_message), errors)
 
     @patch('src.gtfs_flex_validation.CanonicalValidator')
     def test_is_gtfs_flex_valid_with_pathways_items(self, mock_canonical_validator):
@@ -477,7 +556,8 @@ class TestFailureGTFSFlexValidation(unittest.TestCase):
         self.validator.download_single_file = MagicMock(return_value=expected_downloaded_file_path)
 
         # Act
-        is_valid, validation_message = self.validator.is_gtfs_flex_valid()
+        with patch.object(GTFSFlexValidation, 'clean_up'):
+            is_valid, validation_message = self.validator.is_gtfs_flex_valid()
 
         # Assert
         self.assertFalse(is_valid)
@@ -499,7 +579,8 @@ class TestFailureGTFSFlexValidation(unittest.TestCase):
         self.validator.download_single_file = MagicMock(return_value=expected_downloaded_file_path)
 
         # Act
-        is_valid, validation_message = self.validator.is_gtfs_flex_valid()
+        with patch.object(GTFSFlexValidation, 'clean_up'):
+            is_valid, validation_message = self.validator.is_gtfs_flex_valid()
 
         # Assert
         self.assertFalse(is_valid)
@@ -530,6 +611,31 @@ class TestFailureGTFSFlexValidation(unittest.TestCase):
 
         # Assert
         self.assertFalse(is_valid)
+
+    def test_parse_validation_errors_reads_validator_json_text(self):
+        # Arrange
+        errors = '[{"code": "INVALID_FIELD", "sampleNotices": []}]'
+
+        # Act
+        validation_errors = GTFSFlexValidation.parse_validation_errors(errors)
+
+        # Assert
+        self.assertEqual(validation_errors, [{'code': 'INVALID_FIELD', 'sampleNotices': []}])
+
+    def test_format_validation_errors_serializes_errors_as_json_text(self):
+        # Arrange
+        errors = [{'code': 'INVALID_FIELD', 'sampleNotices': [{'fieldName': 'invalid_field'}]}]
+
+        # Act
+        validation_message = GTFSFlexValidation.format_validation_errors(errors)
+
+        # Assert
+        self.assertEqual(
+            json.loads(validation_message),
+            [{'code': 'INVALID_FIELD', 'sampleNotices': [{'fieldName': 'invalid_field'}]}]
+        )
+        self.assertNotIn("'", validation_message)
+        self.assertFalse(validation_message.startswith('"'))
 
     @patch.object(GTFSFlexValidation, 'is_gtfs_flex_valid')
     def test_validate_facade(self, mock_is_gtfs_flex_valid):


### PR DESCRIPTION
## Dev Board Ticket

- https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/3657

## Changes
- Updated `gtfs-canonical-validator` to `0.0.9`.
- Parse validator error/info payloads returned as JSON strings.
- Format validation error messages as valid JSON with double quotes instead of Python stringified dict/list output.
- Added regression coverage for JSON-string validator errors and parseable validation messages.

## Testing
```
python -m coverage run --source=src -m unittest discover -s tests/unit_tests
..............
.......
Ran 55 tests in 99.101s

OK
```